### PR TITLE
Removed ACS sliver polygons with area < 0.01 sq mi.

### DIFF
--- a/src/data/acs.py
+++ b/src/data/acs.py
@@ -44,11 +44,14 @@ def get_census_acs_pop(crs=2263, mask=None):
 
     census_acs_pop.to_crs(crs, inplace=True)
 
-    census_acs_pop.rename(
-        columns={"B01003_001E": "population"}, inplace=True
-    )
+    census_acs_pop.rename(columns={"B01003_001E": "population"}, inplace=True)
 
     if mask is not None:
         census_acs_pop = gpd.clip(census_acs_pop, mask)
 
+    census_acs_pop['area'] = census_acs_pop['geometry'].area
+
+    # Remove post-clip sliver polygons with area < .01 sq mi 
+    census_acs_pop = census_acs_pop[census_acs_pop.area > 278784]
+    
     return census_acs_pop


### PR DESCRIPTION
The ACS population layer had some "sliver polygons" at the edges left over from the clip by borough boundaries. I compared the layer against NYC's census tracts layer (which doesn't have population) to find a suitable area cutoff. .01 sq mi  removes all the slivers while keeping all the real tracts.   